### PR TITLE
Proposed fix to Submit input

### DIFF
--- a/cpm/C.C
+++ b/cpm/C.C
@@ -26,6 +26,7 @@
 #include    <cpm.h>
 #include    <exec.h>
 #include    <stat.h>
+#include    <signal.h>
 
 /*
  *  C command
@@ -169,12 +170,15 @@ int main(int argc, char **argv)
 {
     register char *cp, *xp;
     short       i;
+    signal_t prev_sig;
 
+    prev_sig=signal(SIGINT,SIG_IGN);
     fprintf(stderr, "Hi-Tech C Compiler (CP/M-80) V3.09-7\n");
     fprintf(stderr, "Copyright (C) 1984-87 HI-TECH SOFTWARE\n");
 #if EDUC
     fprintf(stderr, "Licensed for Educational purposes only\n");
 #endif  EDUC
+    signal(SIGINT,prev_sig);
     if (argc == 1)
         argv = _getargs((char *)0, PROMPT);
     setup();

--- a/cpm/SIGNAL.C
+++ b/cpm/SIGNAL.C
@@ -26,5 +26,5 @@ _sigchk()
 		return;
 	if(where == SIG_DFL)
 		exit(0);
-	(*where)(0);
+	((int(*)())where)(0);
 }

--- a/dist/SIGNAL.H
+++ b/dist/SIGNAL.H
@@ -26,7 +26,7 @@
 #define	SIGINT	1		/* control-C */
 #endif
 
-typedef void (*signal_t) (int);
+typedef void* signal_t;
 #define	SIG_DFL	((signal_t)0)	/* default action is to exit */
 #define	SIG_IGN	((signal_t)1)	/* ignore them */
 

--- a/stdio/GETARGS.C
+++ b/stdio/GETARGS.C
@@ -52,6 +52,7 @@
 #include    <ctype.h>
 #include    <string.h>
 #include    <sys.h>
+#include    <signal.h>
 
 #define MAXARGS 200         /* max number of arguments */
 #define MAXLEN  100         /* max length of an argument */
@@ -209,8 +210,11 @@ static char nxtch()
     {
         if (!bp)
             bp = alloc(256);
-        if (isatty(fileno(stdin)))
+        if (isatty(fileno(stdin))) {
+            signal_t prev=signal(SIGINT,SIG_IGN);
             fprintf(stderr, "%s> ", name);
+            signal(SIGINT,prev);
+        }
         gets(bp);
         str = bp;
     }


### PR DESCRIPTION
Based on analysis of conflicts between reads and write, this is indeed created by the sigcheck called in writes that performs a read. When we write, we indirectly read if there is something in the buffer...

All considerations, and tests are in issue #9.