### PR TITLE
backport float source from 7.80pl2

### DIFF
--- a/float/ACOS.C
+++ b/float/ACOS.C
@@ -1,11 +1,12 @@
 #include	<math.h>
 
+#define	PI	3.14159265358979
+#define	TWO_PI	6.28318530717958
+#define	HALF_PI	1.570796326794895
+
 double
 acos(x)
 double	x;
 {
-	double	y;
-
-	y = sqrt(1 - x*x);
-	return atan(y/x);
+	return HALF_PI - asin(x);
 }

--- a/float/ASIN.C
+++ b/float/ASIN.C
@@ -1,11 +1,23 @@
 #include	<math.h>
 
+#define	PI	3.14159265358979
+#define	TWO_PI	6.28318530717958
+#define	HALF_PI	1.570796326794895
+
 double
 asin(x)
 double	x;
 {
 	double	y;
+	double	sgn;
 
-	y = sqrt(1 - x*x);
-	return atan(x/y);
+	if(fabs(x) > 1.0)
+		return 0.0;
+	sgn = 1.0;
+	y = sqrt(1.0 - x*x);
+	if(fabs(x) < 0.71)
+		return atan(x/y);
+	if(x < 0.0)
+		return -(HALF_PI - atan(-y/x));
+	return (HALF_PI - atan(y/x));
 }

--- a/float/ATAN.C
+++ b/float/ATAN.C
@@ -1,24 +1,28 @@
 #include	<math.h>
 
+#define	PI	3.14159265358979
+#define	TWO_PI	6.28318530717958
+#define	HALF_PI	1.570796326794895
+
 double
 atan(f)
 double	f;
 {
-	static double	coeff_a[] =
+	static const double	coeff_a[] =
 	{
-		33.05861847399,
-		58.655751569,
-		32.3907948562,
-		5.853195211263,
-		0.1952374193623,
-		-.002434603300441
+		33.058618473989548,
+		58.655751569001961,
+		32.390974856200445,
+		5.8531952112628600,
+		0.19523741936234277,
+		-.0024346033004411264
 	};
-	static double	coeff_b[] =
+	static const double	coeff_b[] =
 	{
-		33.05861847399,
-		69.67529105952,
-		49.00434821822,
-		12.97557886271,
+		33.058618473992416,
+		69.675291059524653,
+		49.004348218216250,
+		12.975578862709239,
 		1.0
 	};
 	int	recip;
@@ -32,6 +36,6 @@ double	f;
 	val_squared = val * val;
 	val *= eval_poly(val_squared, coeff_a, 5)/eval_poly(val_squared, coeff_b, 4);
 	if(recip)
-		val = 1.570796326795 - val;
+		val = HALF_PI - val;
 	return f < 0.0 ? -val : val;
 }

--- a/float/ATAN2.C
+++ b/float/ATAN2.C
@@ -1,5 +1,9 @@
 #include	<math.h>
 
+#define	PI	3.14159265358979
+#define	TWO_PI	6.28318530717958
+#define	HALF_PI	1.570796326794895
+
 double
 atan2(x, y)
 double	x, y;
@@ -10,15 +14,15 @@ double	x, y;
 		v = atan(x/y);
 		if( y < 0.0)
 			if(x >= 0.0)
-				v += 3.14159265358979;
+				v += PI;
 			else
-				v -= 3.14159265358979;
+				v -= PI;
 		return v;
 	}
 	v = -atan(y/x);
 	if(x < 0.)
-		v -= 1.57079632679489;
+		v -= HALF_PI;
 	else
-		v += 1.57079632679489;
+		v += HALF_PI;
 	return v;
 }

--- a/float/ATAN2.C
+++ b/float/ATAN2.C
@@ -16,7 +16,7 @@ double	x, y;
 		return v;
 	}
 	v = -atan(y/x);
-	if(y < 0.)
+	if(x < 0.)
 		v -= 1.57079632679489;
 	else
 		v += 1.57079632679489;

--- a/float/COS.C
+++ b/float/COS.C
@@ -1,10 +1,16 @@
 #include	<math.h>
 
+#define	PI	3.14159265358979
+#define	TWO_PI	6.28318530717958
+#define	HALF_PI	1.570796326794895
+
 double
 cos(f)
 double	f;
 {
 	/* cos is pi/2 out of phase with sin, so ... */
 
-	return sin(f + 1.570796326795);
+	if(f > PI)
+		return sin(f - (PI+HALF_PI));
+	return sin(f + HALF_PI);
 }

--- a/float/EVALPOLY.C
+++ b/float/EVALPOLY.C
@@ -1,6 +1,7 @@
 double
 eval_poly(x, d, n)
-double	x, d[];
+double	x;
+const double * d;
 int	n;
 {
 	int	i;

--- a/float/EXP.C
+++ b/float/EXP.C
@@ -8,7 +8,7 @@ double x;
 	int	exp;
 	char	sign;
 
-	static double coeff[] =
+	const static double coeff[] =
 	{
 		1.0000000000e+00,
 		6.9314718056e-01,
@@ -40,12 +40,22 @@ double
 pow(x, y)
 double	x, y;
 {
-	if(y == 0.0)
-		return 1.0;
-	if(x < 0.0)
-		return 0.0;
+	unsigned char	sign = 0;
+	unsigned long	yi;
+	
 	if(x == 0.0)
 		return 0.0;
+	if(y == 0.0)
+		return 1.0;
+	if(x < 0.0) {
+		yi = (unsigned long)y;
+		if(yi != y)
+			return 0.0;
+		sign = yi & 1;
+		x = -x;
+	}
 	x = exp(log(x) * y);
+	if(sign)
+		return -x;
 	return x;
 }

--- a/float/LOG.C
+++ b/float/LOG.C
@@ -7,7 +7,7 @@ double	x;
 {
 	int	exp;
 
-	static double coeff[] =
+	static const double coeff[] =
 	{
 		 0.0000000000,	/* a0 */
 		 0.9999964239,	/* a1 */

--- a/float/SIN.C
+++ b/float/SIN.C
@@ -1,49 +1,50 @@
 #include	<math.h>
 
+#define	PI	3.14159265358979
+#define	TWO_PI	6.28318530717958
+#define	HALF_PI	1.570796326794895
+
 double
 sin(f)
 double	f;
 {
-	static double	coeff_a[] =
+	const static double	coeff_a[] =
 	{
-		 0.1357884e8,
-		-0.49429081e7,
-		 0.440103053e6,
-		-0.138472724e5,
-		 0.145968841e3
+		 207823.68416961012,
+		-76586.415638846949,
+		 7064.1360814006881,
+		-237.85932457812158,
+		 2.8078274176220686
 	};
-	static double	coeff_b[] =
+	const static double	coeff_b[] =
 	{
-		 0.864455865e7,
-		 0.408179225e6,
-		 0.946309610e4,
-		 0.132653491e3,
+		 132304.66650864931,
+		 5651.6867953169177,
+		 108.99981103712905,
 		 1.0
 	};
-	double	y, y_squared;
-	int	sect, e;
+	double	x2;
+	int	sgn;
 	extern double	eval_poly();
 
+	sgn = 0;
 	if(f < 0.0) {
 		f = -f;
-		sect = 2;
-	} else
-		sect = 0;
-	f *= .63661977237;
-	if(f > 4.0)
-		f -= 4.0 * floor(f/4.0);
+		sgn = 1;
+	}
+	f *= 1.0/TWO_PI;
+	f = 4.0 * (f - floor(f));
 	if(f > 2.0) {
 		f -= 2.0;
-		sect = 2 - sect;
+		sgn = !sgn;
 	}
-	y = f - (e = (int)f);
-	sect = (e + sect) % 4;
-	if(sect & 1)
-		y = 1.0 - y;
-	if(sect & 2)
-		y = -y;
-	y_squared = y * y;
-	return y * eval_poly(y_squared, coeff_a, 4) / eval_poly(y_squared, coeff_b, 4);
+	if( f > 1.0)
+		f = 2.0 - f;
+	x2 = f * f;
+	f *= eval_poly(x2, coeff_a, 4) / eval_poly(x2, coeff_b, 3);
+	if(sgn)
+		return -f;
+	return f;
 }
 
 

--- a/float/SINH.C
+++ b/float/SINH.C
@@ -1,3 +1,4 @@
+
 #include	<math.h>
 
 double


### PR DESCRIPTION
The v3.09 floating point library is known for being fast, but inaccurate.

Here's some backported code from the v7.80pl2 floating point library in which they address some of the inaccuracy.
 - fixed some typos in `atan()` [coefficients](https://github.com/agn453/HI-TECH-Z80-C/compare/master...feilipu:master#diff-ed75242f80d07c4db12e3375e2e91a440d24442741b1d77bfce64f95a85a655dL11), which also flows on to affect `acos()` and `asin()`.
 - improved the accuracy of the polynomial estimation for `asin()` and `acos()` by restricting the range of the polynomial in use.
 - changed coefficient type to `const`, which potentially saves copying them from ROM, or allows other optimisation (IDK what this compiler actually does in this case though).
 - correct the sign of `atan2()` to reflect the standard usage (or perhaps it was an error).
 - allow integer powers of negative bases.
 - fixes to the intrinsic `float.as` floating point arithmetic functions.

Note that these fixes have not been further tested. _caveat emptor_.