### PR TITLE
backport assorted library patches from 7.80pl2

### DIFF
--- a/cpm/ABORT.C
+++ b/cpm/ABORT.C
@@ -2,6 +2,7 @@
 
 static char	mess[] = "Fatal error - program aborted\r\n$";
 
+void
 abort()
 {
 	bdos(CPMWCOB, mess);

--- a/float/LTOF.AS
+++ b/float/LTOF.AS
@@ -7,8 +7,8 @@
 	global	fpnorm
 
 lbtof:
-	ld	e,a
-	ld	d,0
+	ld	l,a
+	ld	h,0
 litof:
 	ex	de,hl		;put arg in de
 	ld	l,0		;zero top byte
@@ -17,10 +17,10 @@ b3tof:
 	jp	fpnorm
 
 abtof:
-	ld	e,a
+	ld	l,a
 	rla
 	sbc	a,a
-	ld	d,a
+	ld	h,a
 
 aitof:
 	bit	7,h		;negative?
@@ -37,10 +37,43 @@ lltof:
 	ld	a,h		;anything in top byte?
 	or	a
 	jr	z,b3tof		;no, just do 3 bytes
-	ld	e,d		;shift down 8 bits
-	ld	d,l
-	ld	l,h
-	ld	h,64+24+8	;the 8 compensates for the shift
+	ld	c,0
+;	Do it the hard way
+slop:
+	ld	a,h
+	cp	1		;last shift coming up?
+	jr	z,slop2
+	srl	h
+	rr	l
+	rr	d
+	rr	e
+	inc	c
+	jr	slop
+slop2:
+	inc	e
+	jr	nz,slop3
+	inc	d
+	jr	nz,slop3
+	inc	l
+	jr	nz,slop3
+	inc	h
+slop3:
+	srl	h
+	rr	l
+	rr	d
+	rr	e
+	ld	a,h
+	or	a
+	jr	z,slop4
+	srl	h
+	rr	l
+	rr	d
+	rr	e
+	inc	c
+slop4:
+	ld	a,c
+	add	a,64+25
+	ld	h,a
 	jp	fpnorm		;and normalize it
 
 altof:

--- a/gen/ATOL.C
+++ b/gen/ATOL.C
@@ -14,7 +14,8 @@ register char *	s;
 	if(*s == '-') {
 		sign++;
 		s++;
-	}
+	} else if(*s == '+')
+		s++;
 	while(isdigit(*s))
 		a = a*10L + (*s++ - '0');
 	if(sign)

--- a/gen/BRELOP.AS
+++ b/gen/BRELOP.AS
@@ -1,5 +1,5 @@
 ;	byte relational	operation - returns flags correctly for
-;	comparision of words in a and c
+;	comparision of words in a and b
 
 	psect	text
 	global	brelop

--- a/gen/FRELOP.AS
+++ b/gen/FRELOP.AS
@@ -18,27 +18,21 @@ frelop:
 	ld	a,h		;get the sign of the LHS
 	or	1		;ensure zero flag is reset, set sign flag
 	pop	bc		;unjunk stack
-	jp	1f		;return	with sign of LHS
+	jr	1f		;return	with sign of LHS
 2:
-	ld	a,h		;test for differing exponents
-	sub	d		;compare with the other
-	jr	z,2f		;the same, go for mantissas
-	xor	h		;complement sign flag if operands -ve
-	or	1		;reset zero flag
-	pop	bc		;unjunk stack
-	jp	1f		;and return
-2:
-	or	a
+	ld	a,d		;preserve sign flag
+	res	7,d		;clear sign flag
+	res	7,h		;and the other
+	and	80h		;mask out sign flag
 	sbc	hl,de		;set the flags
 	pop	hl		;low word of 1st into hl again
-	jr	nz,1f		;go return if not zero
+	jr	nz,togs		;go fixup sign flag if different
 	sbc	hl,bc		;now set flags on basis	of low word
 	jr	z,1f		;if zero, all ok
-	ld	a,2		;make non-zero
-	rra			;rotate	carry into sign
-	or	a		;set minus flag
-	rlca			;put carry flag	back
-
+togs:
+	rr	h		;rotate	carry into sign
+	xor	h		;toggle sign if necessary
+	or	1		;reset zero flag
 1:
 	exx			;get return address
 	jp	(hl)		;and return with stack clean

--- a/gen/IDIV.AS
+++ b/gen/IDIV.AS
@@ -21,7 +21,7 @@ lmod:
 
 ldiv:
 	xor	a
-	ex	af,af'
+	push	af
 	ex	de,hl
 	jr	dv1
 
@@ -30,14 +30,17 @@ adiv:
 	ld	a,h
 	xor	d		;set sign flag for quotient
 	ld	a,h		;get sign of dividend
-	ex	af,af'
+	push	af
 	call	negif
 	ex	de,hl
 	call	negif
 dv1:	ld	b,1
 	ld	a,h
 	or	l
-	ret	z
+	jr	nz,dv8
+	pop	af
+	ret
+
 dv8:	push	hl
 	add	hl,hl
 	jr	c,dv2
@@ -76,7 +79,7 @@ dv3:	ex	(sp),hl
 	djnz	dv4
 	pop	de
 	ex	de,hl
-	ex	af,af'
+	pop	af
 	call	m,negat
 	ex	de,hl
 	or	a			;test remainder sign bit

--- a/gen/LONGJMP.AS
+++ b/gen/LONGJMP.AS
@@ -4,45 +4,50 @@
 	global	_longjmp, _setjmp
 
 _setjmp:
-	pop	bc		;return address
-	ex	(sp),iy
-	pop	de
-	push	iy
+	pop	bc
+	push	de
+	ex	(sp),iy		;jmp_buf ptr to IY
+	pop	de		;old IY to DE
 	ld	hl,0
 	add	hl,sp
-	ld	(iy+0),l
+	ld	(iy+0),l	;save SP in jmp_buf
 	ld	(iy+1),h
 	push	ix
 	pop	hl
-	ld	(iy+2),l
+	ld	(iy+2),l	;save IX (frame ptr) in jmp_buf
 	ld	(iy+3),h
-	ld	(iy+4),c
+	ld	(iy+4),c	;return address to jmp_buf
 	ld	(iy+5),b
-	ld	(iy+6),e
+	ld	(iy+6),e	;save IY in jmp_buf
 	ld	(iy+7),d
-	push	bc
 	ld	hl,0		;setjmp returns 0
-	push	de		;restore iy
+	push	de		;restore IY
 	pop	iy
+	push	bc		;return address -> BC
 	ret
 
 _longjmp:
-	pop	bc		;return address - junk now
-	pop	iy		;argument
-	pop	de		;and return value
-	ld	l,(iy+0)
+	push	de
+	pop	iy		;jmp_buf ptr to IY
+	ld	e,c		;return val to DE
+	ld	d,b
+	ld	l,(iy+0)	;restore SP from jmp_buf
 	ld	h,(iy+1)
-	ld	sp,hl			;stack pointer
-	ld	l,(iy+2)
+	ld	sp,hl
+	ld	l,(iy+2)	;restore IX (frame ptr) from jmp_buf
 	ld	h,(iy+3)
 	push	hl
 	pop	ix
-	ld	l,(iy+4)
+	ld	l,(iy+4)	;return address
 	ld	h,(iy+5)
-	ld	c,(iy+6)
+	push	hl
+	ld	c,(iy+6)	;restore IY from jmp_buf
 	ld	b,(iy+7)
 	push	bc
 	pop	iy
-	push	hl
 	ex	de,hl		;get arg into hl
+	ld	a,l
+	or	h
+	ret	nz		;not allowed to return 0
+	inc	l
 	ret

--- a/gen/LRELOP.AS
+++ b/gen/LRELOP.AS
@@ -17,7 +17,9 @@ lrelop:
 	xor	d
 	jp	p,2f		;the same, so ok
 	ld	a,h		;get the sign of the LHS
-	or	1		;ensure zero flag is reset, set sign flag
+	or	2		;ensure zero flag is reset, set sign flag
+	ld	a,d		;get RHS
+	rla			;rotate hi bit into carry - Z and S unchanged
 	pop	hl		;unjunk stack
 	jp	1f		;return	with sign of LHS
 2:

--- a/gen/RAND.C
+++ b/gen/RAND.C
@@ -8,5 +8,5 @@ unsigned x;
 
 rand()
 {
-	return(((randx = randx*1103515245 + 12345)>>16) & 077777);
+	return(((randx = randx*1103515245L + 12345)>>16) & 077777);
 }

--- a/gen/STRFTIME.C
+++ b/gen/STRFTIME.C
@@ -309,7 +309,7 @@ static void strfmt(char *str, char *fmt, ...)
                         while (ilen)
                         {
                               ival %= pow[ilen--];
-                              *str++ = '0' + ival / pow[ilen];
+                              *str++ = (char)('0' + ival / pow[ilen]);
                         }
                   }
             }

--- a/stdio/FILBUF.C
+++ b/stdio/FILBUF.C
@@ -1,5 +1,5 @@
 /*
- *	_filbuf for Zios stdio
+ *	_filbuf for HI-TECH C stdio
  */
 
 extern int	read(int, void *, int);
@@ -28,5 +28,5 @@ register FILE *	f;
 	}
 	f->_ptr = f->_base;
 	f->_cnt--;
-	return((unsigned)*f->_ptr++);
+	return((unsigned char)*f->_ptr++);
 }

--- a/stdio/GETW.C
+++ b/stdio/GETW.C
@@ -11,5 +11,5 @@ register FILE *	stream;
 
 	if((lo = getc(stream)) == EOF || (hi = getc(stream)) == EOF)
 		return EOF;
-	return (hi << 8) + (lo & 0xFF);
+	return (hi << 8) | (lo & 0xFF);
 }

--- a/stdio/UNGETC.C
+++ b/stdio/UNGETC.C
@@ -1,14 +1,14 @@
 #include	<stdio.h>
 
 /*
- *	ungetc for Zios
+ *	ungetc for HI-TECH C
  */
 
 ungetc(c, stream)
 int		c;
 register FILE *	stream;
 {
-	if(c == EOF || !(stream->_flag & _IOREAD) ||
+	if(c == EOF || !(stream->_flag & _IOREAD) || stream->_flag & _IODIRN ||
 		stream->_base == (char *)NULL || stream->_cnt == BUFSIZ)
 		return(EOF);
 	if(stream->_ptr == stream->_base)


### PR DESCRIPTION
A few additional, mostly not urgent, patches from the 7.80pl2 library source code.

- `lbtof`, `abtof` loaded wrong registers.
- `lltof` improved conversion accuracy by up to 7 bits.
- `atol()` recognise `+` in number. i.e. `+12345678`
- relational operation fixes, including avoiding `ex af af'` operation (some targets use this alternate register for interrupts).
- `_setjmp` and `_longjmp` fixes.
- `idiv` fixes.
- miscellaneous casts added and typos fixed.

That's all the fixes I can scan without extensively reworking the library functions.
Which I think would be the wrong direction to go with maintenance.