### PR TITLE
Simple fix to align STDLIB.H with other headers 

### DIFF
--- a/dist/STDLIB.H
+++ b/dist/STDLIB.H
@@ -1,3 +1,6 @@
+#ifndef _HTC_STDLIB_H
+#define _HTC_STDLIB_H
+
 /*	Standard utility functions */
 
 #ifndef	_STDDEF
@@ -34,3 +37,5 @@ typedef int (*__qsort_compf)(void *, void *);  /* workaround compiler bug */
 extern void	 qsort(void *, size_t, size_t, __qsort_compf);
 extern int	 abs(int);
 extern long	 labs(long);
+
+#endif


### PR DESCRIPTION
Header Protection Macros