### PR TITLE
Fix `environ` missing null terminator, `getenv` reading lots of uninitialized memory

### DIFF
--- a/stdio/GETENV.C
+++ b/stdio/GETENV.C
@@ -19,7 +19,7 @@ static char loadenv(char *name, char **avec, char *abuf, short *i,
 
     if((fp = fopen(name, "r")) == NULL) return(0);
 
-    while((*i) < avsize && fgets(abuf, absize, fp)) {
+    while((*i) < avsize - 1 && fgets(abuf, absize, fp)) {
         cp = sbrk(strlen(abuf)+1);
         strcpy(cp, abuf);
         cp[strlen(cp)-1] = 0;
@@ -79,7 +79,7 @@ char * getenv(char * s)
 #else
         loadenv(envname+4,avec,abuf,&i,av,ab);
 #endif
-        avec[i] = 0;
+        avec[i++] = 0;
         xp = (char **)sbrk(i * sizeof avec[0]);
         memcpy(xp, avec, i * sizeof avec[0]);
         environ = xp;


### PR DESCRIPTION
This fixes a bug whereby `environ` was not null-terminated as it supposed to be, so `getenv` reads past the end of the array, reading lots of strings from arbitrary, uninitialized memory.

This also fixes a second bug which wrote beyond the end of local array `avec` if all slots were used.

The code in `getenv` loads the environment into `environ[]`, a NULL-terminated array of pointers to strings.

But it fails to set a null terminator.  It write a null terminator to its local array, but fails to include that in the heap copy made for `environ`.

Every time `getenv` is called, if there's no `ENVIRON` file on disk, or if the name is not one set in the environment file, `getenv` reads far past the end of the `environ` array.

It keeps going, reading arbitrary, uninitialized memory, until it eventually finds a null pointer by luck.

Programs that use `environ` directly see a list of junk strings following the environment, due to the missing null pointer.  That's how I noticed this bug.  (But unix programs that expect to use `environ` are iffy with this libc anyway, because `environ` is not set until the first call to `getenv`).